### PR TITLE
Fixed over/underflow and possible segfaults

### DIFF
--- a/cs50.c
+++ b/cs50.c
@@ -121,9 +121,9 @@ GetDouble(void)
         // leading and/or trailing whitespace) was provided
         char *endptr = NULL;
         int const errnocpy = errno;
-
+    
         double d = strtod(line, &endptr);
-        if (strlen(line) && errno != ERANGE && *endptr == '\0' && isfinite(d))
+        if (strlen(line) && errno != ERANGE && !*endptr && isfinite(d))
         {
             free(line);
             return d;
@@ -164,7 +164,7 @@ GetFloat(void)
         int const errnocpy = errno;
 
         float f = strtof(line, &endptr);
-        if (strlen(line) && errno != ERANGE && *endptr == '\0' && isfinite(f))
+        if (strlen(line) && errno != ERANGE && !*endptr && isfinite(f))
         {
             free(line);
             return f;
@@ -209,7 +209,7 @@ GetInt(void)
          * between INT_MAX and INT_MIN. On most systems
          * a long is the same size as an int but not on all. */
         long n = strtol(line, &endptr, BASE);
-        if (strlen(line) && errno != ERANGE && *endptr == '\0' && n <= INT_MAX
+        if (strlen(line) && errno != ERANGE && !*endptr && n <= INT_MAX
                 && n >= INT_MIN)
         {
             free(line);
@@ -252,7 +252,7 @@ GetLongLong(void)
         int const errnocpy = errno;
 
         long long n = strtoll(line, &endptr, BASE);
-        if (strlen(line) && errno != ERANGE && *endptr == '\0')
+        if (strlen(line) && errno != ERANGE && !*endptr)
         {
             free(line);
             return n;

--- a/cs50.c
+++ b/cs50.c
@@ -117,8 +117,9 @@ GetDouble(void)
 
         // return a double if only a double (possibly with
         // leading and/or trailing whitespace) was provided
-        char *endptr;
+        char *endptr = NULL;
         int errnocpy = errno;
+
         double d = strtod(line, &endptr);
         if (errno != ERANGE && *endptr == '\0')
         {
@@ -157,8 +158,9 @@ GetFloat(void)
 
         // return a float if only a float (possibly with
         // leading and/or trailing whitespace) was provided
-        char *endptr;
+        char *endptr = NULL;
         int errnocpy = errno;
+
         float f = strtof(line, &endptr);
         if (errno != ERANGE && *endptr == '\0')
         {
@@ -198,8 +200,9 @@ GetInt(void)
 
         // return an int if only an int (possibly with
         // leading and/or trailing whitespace) was provided
-        char *endptr;
+        char *endptr = NULL;
         int errnocpy = errno;
+
         /* There is no strtoi() so we must check if n is
          * between INT_MAX and INT_MIN. On most systems
          * a long is the same size as an int but not on all. */
@@ -242,8 +245,9 @@ GetLongLong(void)
 
         // return a long long and only a long long, checking for
         // overflow. Will skip over whitespace.
-        char *endptr;
+        char *endptr = NULL;
         int errnocpy = errno;
+
         long long n = strtoll(line, &endptr, BASE);
         if (errno != ERANGE && *endptr == '\0')
         {

--- a/cs50.c
+++ b/cs50.c
@@ -36,21 +36,43 @@
  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ * Contributors:
+ *   Chad Sharp <crossroads1112@riseup.net>
  ***************************************************************************/
-
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-
+#include <errno.h> // Provides errno and ERANGE macro
 #include "cs50.h"
 
-/**
- * Reads a line of text from standard input and returns the equivalent
- * char; if text does not represent a char, user is prompted to retry.
- * Leading and trailing whitespace is ignored.  If line can't be read,
- * returns CHAR_MAX.
+#ifndef SIZE_MAX
+#define SIZE_MAX ((size_t) -1)
+#endif
+
+
+
+// Default capacity of buffer for standard input.
+#define CAPACITY 128
+// Base for strtol() and strtoll()
+#define BASE 10
+// Macro to reset errno if it has been changed
+#define RESETERR(VAL) if (errno != VAL) errno = VAL
+// Macro to cleanup upon function termination
+#define CLEANUP(BUF, RET) free(BUF); return RET
+// Macro used when the Get*() (except GetString()) recieve invalid input
+#define RETRY(BUF) free(BUF); printf("Retry: ")
+
+
+
+/*
+ * Reads a line of text from standard input and returns the equivalent char; if
+ * text does not represent a char, user is prompted to retry.  Leading and
+ * trailing whitespace is ignored.  If line can't be read, returns CHAR_MAX.
  */
-char GetChar(void)
+
+char
+GetChar(void)
 {
     // try to get a char from user
     while (true)
@@ -67,25 +89,25 @@ char GetChar(void)
         char c1, c2;
         if (sscanf(line, " %c %c", &c1, &c2) == 1)
         {
-            free(line);
-            return c1;
+            CLEANUP(line, c1);
         }
         else
         {
-            free(line);
-            printf("Retry: ");
+            RETRY(line);
         }
     }
 }
 
-/**
- * Reads a line of text from standard input and returns the equivalent
- * double as precisely as possible; if text does not represent a
- * double, user is prompted to retry.  Leading and trailing whitespace
- * is ignored.  For simplicity, overflow and underflow are not detected.
- * If line can't be read, returns DBL_MAX.
+
+/*
+ * Reads a line of text from standard input and returns the equivalent double
+ * as precisely as possible; if text does not represent a double, user is
+ * prompted to retry.  Leading and trailing whitespace is ignored.
+ * Overflow/underflow detected.  If line can't be read, returns DBL_MAX.
  */
-double GetDouble(void)
+
+double
+GetDouble(void)
 {
     // try to get a double from user
     while (true)
@@ -99,28 +121,31 @@ double GetDouble(void)
 
         // return a double if only a double (possibly with
         // leading and/or trailing whitespace) was provided
-        double d; char c;
-        if (sscanf(line, " %lf %c", &d, &c) == 1)
+        char *endptr;
+        int errnocpy = errno;
+        double d = strtod(line, &endptr);
+        if (errno != ERANGE && *endptr == '\0')
         {
-            free(line);
-            return d;
+            CLEANUP(line, d);
         }
         else
         {
-            free(line);
-            printf("Retry: ");
+            RESETERR(errnocpy);
+            RETRY(line);
         }
     }
 }
 
-/**
- * Reads a line of text from standard input and returns the equivalent
- * float as precisely as possible; if text does not represent a float,
- * user is prompted to retry.  Leading and trailing whitespace is ignored.
- * For simplicity, overflow and underflow are not detected.  If line can't
- * be read, returns FLT_MAX.
+
+/*
+ * Reads a line of text from standard input and returns the equivalent float as
+ * precisely as possible; if text does not represent a float, user is prompted
+ * to retry.  Leading and trailing whitespace is ignored.  If line can't be
+ * read, returns FLT_MAX. Checks for overflow.
  */
-float GetFloat(void)
+
+float
+GetFloat(void)
 {
     // try to get a float from user
     while (true)
@@ -134,28 +159,32 @@ float GetFloat(void)
 
         // return a float if only a float (possibly with
         // leading and/or trailing whitespace) was provided
-        char c; float f;
-        if (sscanf(line, " %f %c", &f, &c) == 1)
+        char *endptr;
+        int errnocpy = errno;
+        float f = strtof(line, &endptr);
+        if (errno != ERANGE && *endptr == '\0')
         {
-            free(line);
-            return f;
+            CLEANUP(line, f);
         }
         else
         {
-            free(line);
-            printf("Retry: ");
+            RESETERR(errnocpy);
+            RETRY(line);
         }
     }
 }
 
-/**
- * Reads a line of text from standard input and returns it as an
- * int in the range of [-2^31 + 1, 2^31 - 2], if possible; if text
- * does not represent such an int, user is prompted to retry.  Leading
- * and trailing whitespace is ignored.  For simplicity, overflow is not
- * detected.  If line can't be read, returns INT_MAX.
+
+/*
+ * Reads a line of text from standard input and returns it as an int in the
+ * range of [-2^31 + 1, 2^31 - 2] (on some systems), if possible; if text does
+ * not represent such an int, user is prompted to retry.  Leading and trailing
+ * whitespace is ignored. Overflow is detected and user is prompted to retry.
+ * If line can't be read, returns INT_MAX.
  */
-int GetInt(void)
+
+int
+GetInt(void)
 {
     // try to get an int from user
     while (true)
@@ -169,28 +198,35 @@ int GetInt(void)
 
         // return an int if only an int (possibly with
         // leading and/or trailing whitespace) was provided
-        int n; char c;
-        if (sscanf(line, " %i %c", &n, &c) == 1)
+        char *endptr;
+        int errnocpy = errno;
+        /* There is no strtoi() so we must check if n is
+         * between INT_MAX and INT_MIN. On most systems
+         * a long is the same size as an int but not on all. */
+        long n = strtol(line, &endptr, BASE);
+        if (errno != ERANGE && *endptr == '\0' && n <= INT_MAX && n >= INT_MIN)
         {
-            free(line);
-            return n;
+            CLEANUP(line, (int) n);
         }
         else
         {
-            free(line);
-            printf("Retry: ");
+            RESETERR(errnocpy);
+            RETRY(line);
         }
     }
 }
 
-/**
- * Reads a line of text from standard input and returns an equivalent
- * long long in the range [-2^63 + 1, 2^63 - 2], if possible; if text
- * does not represent such a long long, user is prompted to retry.
- * Leading and trailing whitespace is ignored.  For simplicity, overflow
- * is not detected.  If line can't be read, returns LLONG_MAX.
+
+/*
+ * Reads a line of text from standard input and returns an equivalent long long
+ * in the range [-2^63 + 1, 2^63 - 2] (on some sysytems), if possible; if text
+ * does not represent such a long long, user is prompted to retry.  Leading and
+ * trailing whitespace is ignored. Overflow is detected and user prompted to
+ * retry. If line can't be read, returns LLONG_MAX.
  */
-long long GetLongLong(void)
+
+long long
+GetLongLong(void)
 {
     // try to get a long long from user
     while (true)
@@ -202,40 +238,43 @@ long long GetLongLong(void)
             return LLONG_MAX;
         }
 
-        // return a long long if only a long long (possibly with
-        // leading and/or trailing whitespace) was provided
-        long long n; char c;
-        if (sscanf(line, " %lld %c", &n, &c) == 1)
+        // return a long long and only a long long, checking for
+        // overflow. Will skip over whitespace.
+        char *endptr;
+        int errnocpy = errno;
+        long long n = strtoll(line, &endptr, BASE);
+        if (errno != ERANGE && *endptr == '\0')
         {
-            free(line);
-            return n;
+            CLEANUP(line, n);
         }
         else
         {
-            free(line);
-            printf("Retry: ");
+            RESETERR(errnocpy);
+            RETRY(line);
         }
     }
 }
 
-/**
- * Reads a line of text from standard input and returns it as a
- * string (char*), sans trailing newline character.  (Ergo, if
- * user inputs only "\n", returns "" not NULL.)  Returns NULL
- * upon error or no input whatsoever (i.e., just EOF).  Leading
- * and trailing whitespace is not ignored.  Stores string on heap
- * (via malloc); memory must be freed by caller to avoid leak.
+
+/*
+ * Reads a line of text from standard input and returns it as a string, sans
+ * trailing newline character.  (Ergo, if user inputs only "\n", returns "" not
+ * NULL.)  Leading and trailing whitespace is not ignored.  Returns NULL upon
+ * error or no input whatsoever (i.e., just EOF).
  */
-string GetString(void)
+
+
+string
+GetString(void)
 {
     // growable buffer for chars
     string buffer = NULL;
 
     // capacity of buffer
-    unsigned int capacity = 0;
+    size_t capacity = 0;
 
     // number of chars actually in buffer
-    unsigned int n = 0;
+    size_t n = 0;
 
     // character read or EOF
     int c;
@@ -244,30 +283,35 @@ string GetString(void)
     while ((c = fgetc(stdin)) != '\n' && c != EOF)
     {
         // grow buffer if necessary
-        if (n + 1 > capacity)
+        if (n + 1 >= capacity)
         {
-            // determine new capacity: start at 32 then double
+            // determine new capacity: start at CAPACITY then double
             if (capacity == 0)
             {
-                capacity = 32;
+                capacity = CAPACITY;
             }
-            else if (capacity <= (UINT_MAX / 2))
+            else if (capacity <= (SIZE_MAX / 2))
             {
                 capacity *= 2;
             }
+            else if (capacity < (SIZE_MAX - 1))
+            {
+                capacity += ((SIZE_MAX - capacity)/2);
+            }
             else
             {
-                free(buffer);
-                return NULL;
+                CLEANUP(buffer, NULL);
             }
 
             // extend buffer's capacity
-            string temp = realloc(buffer, capacity * sizeof(char));
+            // Better practice to use sizeof(*temp) than sizeof(char);
+            // http://stackoverflow.com/questions/7243872/why-write-sizeofchar-if-char-is-1-by-standard
+            string temp = realloc(buffer, capacity * sizeof(*temp));
             if (temp == NULL)
             {
-                free(buffer);
-                return NULL;
+                CLEANUP(buffer, NULL);
             }
+
             buffer = temp;
         }
 
@@ -281,10 +325,14 @@ string GetString(void)
         return NULL;
     }
 
-    // minimize buffer
-    string minimal = malloc((n + 1) * sizeof(char));
-    strncpy(minimal, buffer, n);
-    free(buffer);
+
+    string minimal = realloc(buffer, (n + 1) * sizeof(*minimal));
+    // Check if realloc failed
+    if (minimal == NULL)
+    {
+        // Minimization failed. Input should still be returned
+        minimal = buffer;
+    }
 
     // terminate string
     minimal[n] = '\0';

--- a/cs50.c
+++ b/cs50.c
@@ -44,6 +44,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h> // Provides errno and ERANGE macro
+#include <math.h> // Provides isfinite()
 #include "cs50.h"
 
 #ifndef SIZE_MAX
@@ -121,7 +122,7 @@ GetDouble(void)
         int errnocpy = errno;
 
         double d = strtod(line, &endptr);
-        if (errno != ERANGE && *endptr == '\0')
+        if (errno != ERANGE && *endptr == '\0' && isfinite(d))
         {
             free(line);
             return d;
@@ -162,7 +163,7 @@ GetFloat(void)
         int errnocpy = errno;
 
         float f = strtof(line, &endptr);
-        if (errno != ERANGE && *endptr == '\0')
+        if (errno != ERANGE && *endptr == '\0' && isfinite(f))
         {
             free(line);
             return f;

--- a/cs50.c
+++ b/cs50.c
@@ -43,6 +43,7 @@
  ***************************************************************************/
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h> // Provides strlen()
 #include <errno.h> // Provides errno and ERANGE macro
 #include <math.h> // Provides isfinite()
 #include "cs50.h"
@@ -55,9 +56,9 @@
 
 // Default capacity of buffer for standard input.
 #define CAPACITY 128
-// Base for strtol() and strtoll()
-#define BASE 10
-
+// Automatically detect if input is octal, decimal or hexidecimal in GetInt and
+// GetLong
+#define BASE 0
 
 
 /*
@@ -119,10 +120,10 @@ GetDouble(void)
         // return a double if only a double (possibly with
         // leading and/or trailing whitespace) was provided
         char *endptr = NULL;
-        int errnocpy = errno;
+        int const errnocpy = errno;
 
         double d = strtod(line, &endptr);
-        if (errno != ERANGE && *endptr == '\0' && isfinite(d))
+        if (strlen(line) && errno != ERANGE && *endptr == '\0' && isfinite(d))
         {
             free(line);
             return d;
@@ -160,10 +161,10 @@ GetFloat(void)
         // return a float if only a float (possibly with
         // leading and/or trailing whitespace) was provided
         char *endptr = NULL;
-        int errnocpy = errno;
+        int const errnocpy = errno;
 
         float f = strtof(line, &endptr);
-        if (errno != ERANGE && *endptr == '\0' && isfinite(f))
+        if (strlen(line) && errno != ERANGE && *endptr == '\0' && isfinite(f))
         {
             free(line);
             return f;
@@ -202,13 +203,14 @@ GetInt(void)
         // return an int if only an int (possibly with
         // leading and/or trailing whitespace) was provided
         char *endptr = NULL;
-        int errnocpy = errno;
+        int const errnocpy = errno;
 
         /* There is no strtoi() so we must check if n is
          * between INT_MAX and INT_MIN. On most systems
          * a long is the same size as an int but not on all. */
         long n = strtol(line, &endptr, BASE);
-        if (errno != ERANGE && *endptr == '\0' && n <= INT_MAX && n >= INT_MIN)
+        if (strlen(line) && errno != ERANGE && *endptr == '\0' && n <= INT_MAX
+                && n >= INT_MIN)
         {
             free(line);
             return (int) n;
@@ -247,10 +249,10 @@ GetLongLong(void)
         // return a long long and only a long long, checking for
         // overflow. Will skip over whitespace.
         char *endptr = NULL;
-        int errnocpy = errno;
+        int const errnocpy = errno;
 
         long long n = strtoll(line, &endptr, BASE);
-        if (errno != ERANGE && *endptr == '\0')
+        if (strlen(line) && errno != ERANGE && *endptr == '\0')
         {
             free(line);
             return n;
@@ -351,3 +353,4 @@ GetString(void)
     // return string
     return minimal;
 }
+

--- a/cs50.c
+++ b/cs50.c
@@ -56,12 +56,6 @@
 #define CAPACITY 128
 // Base for strtol() and strtoll()
 #define BASE 10
-// Macro to reset errno if it has been changed
-#define RESETERR(VAL) if (errno != VAL) errno = VAL
-// Macro to cleanup upon function termination
-#define CLEANUP(BUF, RET) free(BUF); return RET
-// Macro used when the Get*() (except GetString()) recieve invalid input
-#define RETRY(BUF) free(BUF); printf("Retry: ")
 
 
 
@@ -89,11 +83,13 @@ GetChar(void)
         char c1, c2;
         if (sscanf(line, " %c %c", &c1, &c2) == 1)
         {
-            CLEANUP(line, c1);
+            free(line);
+            return c1;
         }
         else
         {
-            RETRY(line);
+            free(line);
+            printf("Retry: ");
         }
     }
 }
@@ -126,12 +122,14 @@ GetDouble(void)
         double d = strtod(line, &endptr);
         if (errno != ERANGE && *endptr == '\0')
         {
-            CLEANUP(line, d);
+            free(line);
+            return d;
         }
         else
         {
-            RESETERR(errnocpy);
-            RETRY(line);
+            errno = errnocpy;
+            free(line);
+            printf("Retry: ");
         }
     }
 }
@@ -164,12 +162,14 @@ GetFloat(void)
         float f = strtof(line, &endptr);
         if (errno != ERANGE && *endptr == '\0')
         {
-            CLEANUP(line, f);
+            free(line);
+            return f;
         }
         else
         {
-            RESETERR(errnocpy);
-            RETRY(line);
+            errno = errnocpy;
+            free(line);
+            printf("Retry: ");
         }
     }
 }
@@ -206,12 +206,14 @@ GetInt(void)
         long n = strtol(line, &endptr, BASE);
         if (errno != ERANGE && *endptr == '\0' && n <= INT_MAX && n >= INT_MIN)
         {
-            CLEANUP(line, (int) n);
+            free(line);
+            return (int) n;
         }
         else
         {
-            RESETERR(errnocpy);
-            RETRY(line);
+            errno = errnocpy;
+            free(line);
+            printf("Retry: ");
         }
     }
 }
@@ -245,12 +247,14 @@ GetLongLong(void)
         long long n = strtoll(line, &endptr, BASE);
         if (errno != ERANGE && *endptr == '\0')
         {
-            CLEANUP(line, n);
+            free(line);
+            return n;
         }
         else
         {
-            RESETERR(errnocpy);
-            RETRY(line);
+            errno = errnocpy;
+            free(line);
+            printf("Retry: ");
         }
     }
 }
@@ -300,7 +304,8 @@ GetString(void)
             }
             else
             {
-                CLEANUP(buffer, NULL);
+                free(buffer);
+                return NULL;
             }
 
             // extend buffer's capacity
@@ -309,7 +314,8 @@ GetString(void)
             string temp = realloc(buffer, capacity * sizeof(*temp));
             if (temp == NULL)
             {
-                CLEANUP(buffer, NULL);
+                free(buffer);
+                return NULL;
             }
 
             buffer = temp;

--- a/cs50.c
+++ b/cs50.c
@@ -316,9 +316,9 @@ GetString(void)
             }
 
             // extend buffer's capacity
-            // Better practice to use sizeof(*temp) than sizeof(char);
+            // Better practice to use sizeof *temp than sizeof(char);
             // http://stackoverflow.com/questions/7243872/why-write-sizeofchar-if-char-is-1-by-standard
-            string temp = realloc(buffer, capacity * sizeof(*temp));
+            string temp = realloc(buffer, capacity * sizeof *temp);
             if (temp == NULL)
             {
                 free(buffer);
@@ -339,7 +339,7 @@ GetString(void)
     }
 
 
-    string minimal = realloc(buffer, (n + 1) * sizeof(*minimal));
+    string minimal = realloc(buffer, (n + 1) * sizeof *minimal);
     // Check if realloc failed
     if (minimal == NULL)
     {

--- a/deb/library50-c-6/Makefile
+++ b/deb/library50-c-6/Makefile
@@ -3,7 +3,7 @@ srcdir = $(prefix)/src
 libdir = $(prefix)/lib
 includedir = $(prefix)/include
 
-CFLAGS = --std=c99
+CFLAGS = -lm --std=c99
 
 all:
 	gcc -c -o cs50.o cs50.c

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -24,7 +24,7 @@ package() {
     cd $srcdir/library50-c/
     install -Dm0644     libcs50.a   "$pkgdir/usr/lib/libcs50.a"
     install -Dm0644     cs50.h      "$pkgdir/usr/include/cs50.h"
-    install -Dm0644     cs50.c      "$pkgdir/usr/src/cs50.h"
+    install -Dm0644     cs50.c      "$pkgdir/usr/src/cs50.c"
 }
 
 pkgver() {

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: Chad "crossroads1112" Sharp <crossroads1112@riseup.net>
+pkgname=libcs50-git
+pkgver=r16.3a50671
+pkgrel=1
+pkgdesc="Harvard's CS50 library"
+arch=('x86_64' 'i686')
+url="cs50.harvard.edu"
+license=('BSD')
+depends=()
+optdepends=()
+makedepends=('git')
+provides=("libcs50")
+source=(git+https://github.com/cs50/library50-c.git)
+md5sums=(SKIP)
+
+
+build(){
+    cd $srcdir/library50-c/
+    gcc -c cs50.c -o cs50.o -ggdb3 -O0 -Wall -Wextra -pedantic
+    ar rcs libcs50.a cs50.o
+}
+
+package() {
+    cd $srcdir/library50-c/
+    install -Dm0644     libcs50.a   "$pkgdir/usr/lib/libcs50.a"
+    install -Dm0644     cs50.h      "$pkgdir/usr/include/cs50.h"
+}
+
+pkgver() {
+  cd "$srcdir/library50-c"
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -16,7 +16,7 @@ md5sums=(SKIP)
 
 build(){
     cd $srcdir/library50-c/
-    gcc -c cs50.c -o cs50.o -ggdb3 -O0 -Wall -Wextra -pedantic
+    gcc -c -lm -std=c99 -ggdb cs50.c -o cs50.o
     ar rcs libcs50.a cs50.o
 }
 
@@ -24,6 +24,7 @@ package() {
     cd $srcdir/library50-c/
     install -Dm0644     libcs50.a   "$pkgdir/usr/lib/libcs50.a"
     install -Dm0644     cs50.h      "$pkgdir/usr/include/cs50.h"
+    install -Dm0644     cs50.c      "$pkgdir/usr/src/cs50.h"
 }
 
 pkgver() {

--- a/rpm/SPECS/library50-c.spec
+++ b/rpm/SPECS/library50-c.spec
@@ -51,7 +51,7 @@ cp %{_sourcedir}/* %{_builddir}/
 
 ############################################################################
 %build
-clang -c -ggdb -std=c99 %{_builddir}/cs50.c -o %{_builddir}/cs50.o
+clang -c -ggdb -std=c99 -lm %{_builddir}/cs50.c -o %{_builddir}/cs50.o
 ar rcs %{_builddir}/libcs50.a %{_builddir}/cs50.o
 
 


### PR DESCRIPTION
What I changed:
 1. All GetInt(), GetFloat(), GetDouble() and GetLongLong() now check for
    overflow (and underflow)
 2. Replace malloc with realloc in GetString() and check its return.
 3. Use size_t's instead of unsigned in GetString()
 4. After capacity > SIZE_MAX / 2, start increasing logrithmically instead of
    exponentially in GetString(). (Possible disadvantage: allocations become increasingly frequent from SIZE_MAX/2 as size approaches SIZE_MAX)

Why I changed it:
 1. Integer/float overflow is undefined behavior. Undefined behavior is bad.
 2. Malloc should be checked because a segfault could occur if it returns null.
    However, it then became apparent that malloc + strncpy could simply be replaced
    with realloc.
 3. size_t's are meant to hold indexes
 4. Allow for inputs (almost) twice as big

How I changed it:
 1. Instead of using sscanf(), I used strto\*() which, stores the last valid
    character in the string in a char\* and if the value is out of range, it stores
    ERANGE in errno. For strtol and strtoll, a base is required as well which in
    the below define instruction is set to 0 which autodetects the base (similar to `%i` as opposed to `%d`). 
 2. Simply used realloc and added a check. If minimization fails, the string is
    still returned (albeit with more than the required amount of memory. Because I
    don't want to change the function declaration, there's no way to notify the
    caller of this.
 3. Changed unsigned to size_t and UINT_MAX to SIZE_MAX
 4. Added else if to the while loop
