### PR TITLE
prevents some get_* from accepting empty strings

### DIFF
--- a/src/cs50.c
+++ b/src/cs50.c
@@ -98,7 +98,7 @@ double get_double(void)
         }
 
         // return a double if only a double was provided
-        if (!isspace(line[0]))
+        if (!isspace(line[0]) && *line)
         {
             char *tail;
             errno = 0;
@@ -138,7 +138,7 @@ float get_float(void)
         }
 
         // return a float if only a float was provided
-        if (!isspace(line[0]))
+        if (!isspace(line[0]) && *line)
         {
             char *tail;
             errno = 0;
@@ -178,7 +178,7 @@ int get_int(void)
         }
 
         // return an int if only an int (in range) was provided
-        if (!isspace(line[0]))
+        if (!isspace(line[0]) && *line)
         {
             char *tail;
             errno = 0;
@@ -214,7 +214,7 @@ long long get_long_long(void)
         }
 
         // return a long long if only a long long (in range) was provided
-        if (!isspace(line[0]))
+        if (!isspace(line[0]) && *line)
         {
             char *tail;
             errno = 0;


### PR DESCRIPTION
when calling `get_double`, `get_float`, `get_int`, or `get_long_long`
and hitting Enter (without providing input), `get_string` returns an
empty string, which escapes the validations by these functions.

this fixes the problem by ensuring that `line` is not an empty
string.