### PR TITLE
checks for EOF

### DIFF
--- a/src/cs50.c
+++ b/src/cs50.c
@@ -300,10 +300,11 @@ string get_string(void)
     }
 
     // if last character read was CR, try to read LF as well
-    if (c == '\r' && (c = fgetc(stdin) != '\n'))
+    if (c == '\r' && (c = fgetc(stdin)) != '\n')
     {
+
         // return NULL if character can't be pushed back onto standard input
-        if (ungetc(c, stdin) == EOF)
+        if (c != EOF && ungetc(c, stdin) == EOF)
         {
             free(buffer);
             return NULL;


### PR DESCRIPTION
* if EOL is \r, c is assigned the result of a boolean expression due to
a misplaced parenthesis.

* no EOF checking before ungetc which would cause buffer to be freed
and NULL to be returned.

this places the parenthesis correctly and checks for EOF before
ungetc.

fyi, it's safe to call `fgetc` past `EOF`, as per the standard §7.19.7.1:

> If the end-of-file indicator for the stream is set, or if the stream is at end-of-file, the end-
> of-file indicator for the stream is set and the `fgetc` function returns `EOF`.