### PR TITLE
adds garbage collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .bash_history
-.build/
 .viminfo
+build/
 lib/
 src/test
 src/test.dSYM

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ test: lib
 clean:
 	rm -rf build/ lib/
 
+# http://valgrind.org/docs/manual/manual-core.html#manual-core.suppress
 gc: lib
 	@echo "\nBe sure you've run: apt-get install -y libgc-dev valgrind\n"
 	clang -ggdb3 -Isrc -O0 -std=c99 -Wall -Werror tests/gc.c -Llib -lcs50 -lgc -o build/gc
-	echo John | valgrind ./build/gc
+	echo John | valgrind --suppressions=./valgrind/libgc.supp ./build/gc

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,8 @@ test: lib
 
 clean:
 	rm -rf build/ lib/
+
+gc: lib
+	@echo "\nBe sure you've run: apt-get install -y libgc-dev valgrind\n"
+	clang -ggdb3 -Isrc -O0 -std=c99 -Wall -Werror tests/gc.c -Llib -lcs50 -lgc -o build/gc
+	echo John | valgrind ./build/gc

--- a/src/cs50.c
+++ b/src/cs50.c
@@ -42,6 +42,7 @@
 
 #include <ctype.h>
 #include <errno.h>
+#include <gc.h>
 #include <math.h>
 #include <stdarg.h>
 #include <stdint.h>
@@ -52,11 +53,15 @@
 #include "cs50.h"
 
 /**
- * Called automatically before execution enters main. Disables buffering for standard output.
+ * Called automatically before execution enters main. 
  */
 __attribute__((constructor))
 static void _init(void)
 {
+    // initialize garbage collector
+    GC_INIT();
+
+    // disable buffering of standard output
     setvbuf(stdout, NULL, _IONBF, 0);
 }
 

--- a/src/cs50.c
+++ b/src/cs50.c
@@ -49,6 +49,15 @@
 #include "cs50.h"
 
 /**
+ * Called automatically before execution enters main. Disables buffering for standard output.
+ */
+__attribute__((constructor))
+void _init(void)
+{
+    setvbuf(stdout, NULL, _IONBF, 0);
+}
+
+/**
  * Reads a line of text from standard input and returns the equivalent
  * char; if text does not represent a char, user is prompted to retry.
  * Leading and trailing whitespace is ignored. If line can't be read,

--- a/src/cs50.c
+++ b/src/cs50.c
@@ -53,6 +53,14 @@
 #include "cs50.h"
 
 /**
+ * Enables garbage collection for library transparently.
+ */
+#define calloc GC_MALLOC
+#define free GC_FREE
+#define malloc GC_MALLOC_ATOMIC
+#define realloc GC_REALLOC
+
+/**
  * Called automatically before execution enters main. 
  */
 __attribute__((constructor))

--- a/src/cs50.c
+++ b/src/cs50.c
@@ -38,6 +38,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _GNU_SOURCE
+
 #include <ctype.h>
 #include <errno.h>
 #include <math.h>
@@ -53,7 +55,7 @@
  * Called automatically before execution enters main. Disables buffering for standard output.
  */
 __attribute__((constructor))
-void _init(void)
+static void _init(void)
 {
     setvbuf(stdout, NULL, _IONBF, 0);
 }

--- a/src/cs50.h
+++ b/src/cs50.h
@@ -41,14 +41,18 @@
 #ifndef _CS50_H
 #define _CS50_H
 
-#define free GC_FREE
-#define malloc GC_MALLOC
-#define realloc GC_REALLOC
-
 #include <float.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdlib.h>
+
+/**
+ * Enables garbage collection transparently.
+ */
+#define calloc GC_MALLOC
+#define free GC_FREE
+#define malloc GC_MALLOC_ATOMIC
+#define realloc GC_REALLOC
 
 /**
  * Our own data type for string variables.

--- a/src/cs50.h
+++ b/src/cs50.h
@@ -41,6 +41,10 @@
 #ifndef _CS50_H
 #define _CS50_H
 
+#define free GC_FREE
+#define malloc GC_MALLOC
+#define realloc GC_REALLOC
+
 #include <float.h>
 #include <limits.h>
 #include <stdbool.h>

--- a/src/cs50.h
+++ b/src/cs50.h
@@ -47,14 +47,6 @@
 #include <stdlib.h>
 
 /**
- * Enables garbage collection transparently.
- */
-#define calloc GC_MALLOC
-#define free GC_FREE
-#define malloc GC_MALLOC_ATOMIC
-#define realloc GC_REALLOC
-
-/**
  * Our own data type for string variables.
  */
 typedef char *string;

--- a/tests/gc.c
+++ b/tests/gc.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+#include "cs50.h"
+
+int main(void)
+{
+    string s = get_string();
+    printf("hello, %s\n", s);
+}

--- a/valgrind/libgc.supp
+++ b/valgrind/libgc.supp
@@ -1,0 +1,10 @@
+{
+   name
+   Memcheck:Cond
+   obj:/usr/lib/x86_64-linux-gnu/libgc.so.*
+}
+{
+   name
+   Memcheck:Value8
+   obj:/usr/lib/x86_64-linux-gnu/libgc.so.*
+}

--- a/valgrind/valgrind.out
+++ b/valgrind/valgrind.out
@@ -1,0 +1,506 @@
+==817== Memcheck, a memory error detector
+==817== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
+==817== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
+==817== Command: ./build/gc
+==817== Parent PID: 1
+==817== 
+==817== Conditional jump or move depends on uninitialised value(s)
+==817==    at 0x4E4D81F: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56B1B: GC_with_callee_saves_pushed (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4EEAE: GC_push_roots (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:GC_push_all_eager
+   fun:GC_with_callee_saves_pushed
+   fun:GC_push_roots
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Conditional jump or move depends on uninitialised value(s)
+==817==    at 0x4E4D824: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56B1B: GC_with_callee_saves_pushed (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4EEAE: GC_push_roots (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:GC_push_all_eager
+   fun:GC_with_callee_saves_pushed
+   fun:GC_push_roots
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Use of uninitialised value of size 8
+==817==    at 0x4E4D621: GC_mark_and_push_stack (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4D82E: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56B1B: GC_with_callee_saves_pushed (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4EEAE: GC_push_roots (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   fun:GC_mark_and_push_stack
+   fun:GC_push_all_eager
+   fun:GC_with_callee_saves_pushed
+   fun:GC_push_roots
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Conditional jump or move depends on uninitialised value(s)
+==817==    at 0x4E4D633: GC_mark_and_push_stack (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4D82E: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56B1B: GC_with_callee_saves_pushed (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4EEAE: GC_push_roots (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:GC_mark_and_push_stack
+   fun:GC_push_all_eager
+   fun:GC_with_callee_saves_pushed
+   fun:GC_push_roots
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Use of uninitialised value of size 8
+==817==    at 0x4E4D661: GC_mark_and_push_stack (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4D82E: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56B1B: GC_with_callee_saves_pushed (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4EEAE: GC_push_roots (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   fun:GC_mark_and_push_stack
+   fun:GC_push_all_eager
+   fun:GC_with_callee_saves_pushed
+   fun:GC_push_roots
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Use of uninitialised value of size 8
+==817==    at 0x4E4A476: GC_find_header (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E46A02: GC_add_to_black_list_stack (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4D82E: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56B1B: GC_with_callee_saves_pushed (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4EEAE: GC_push_roots (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   fun:GC_find_header
+   fun:GC_add_to_black_list_stack
+   fun:GC_push_all_eager
+   fun:GC_with_callee_saves_pushed
+   fun:GC_push_roots
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Conditional jump or move depends on uninitialised value(s)
+==817==    at 0x4E4A485: GC_find_header (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E46A02: GC_add_to_black_list_stack (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4D82E: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56B1B: GC_with_callee_saves_pushed (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4EEAE: GC_push_roots (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:GC_find_header
+   fun:GC_add_to_black_list_stack
+   fun:GC_push_all_eager
+   fun:GC_with_callee_saves_pushed
+   fun:GC_push_roots
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Use of uninitialised value of size 8
+==817==    at 0x4E4A4AF: GC_find_header (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E46A02: GC_add_to_black_list_stack (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4D82E: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56B1B: GC_with_callee_saves_pushed (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4EEAE: GC_push_roots (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   fun:GC_find_header
+   fun:GC_add_to_black_list_stack
+   fun:GC_push_all_eager
+   fun:GC_with_callee_saves_pushed
+   fun:GC_push_roots
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Use of uninitialised value of size 8
+==817==    at 0x4E46A42: GC_add_to_black_list_stack (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4D82E: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56B1B: GC_with_callee_saves_pushed (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4EEAE: GC_push_roots (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   fun:GC_add_to_black_list_stack
+   fun:GC_push_all_eager
+   fun:GC_with_callee_saves_pushed
+   fun:GC_push_roots
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Conditional jump or move depends on uninitialised value(s)
+==817==    at 0x4E4D81F: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56557: GC_push_all_stacks (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:GC_push_all_eager
+   fun:GC_push_all_stacks
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Conditional jump or move depends on uninitialised value(s)
+==817==    at 0x4E4D824: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56557: GC_push_all_stacks (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:GC_push_all_eager
+   fun:GC_push_all_stacks
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Use of uninitialised value of size 8
+==817==    at 0x4E4D621: GC_mark_and_push_stack (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4D82E: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56557: GC_push_all_stacks (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   fun:GC_mark_and_push_stack
+   fun:GC_push_all_eager
+   fun:GC_push_all_stacks
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Conditional jump or move depends on uninitialised value(s)
+==817==    at 0x4E4D633: GC_mark_and_push_stack (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4D82E: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56557: GC_push_all_stacks (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:GC_mark_and_push_stack
+   fun:GC_push_all_eager
+   fun:GC_push_all_stacks
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Use of uninitialised value of size 8
+==817==    at 0x4E4D661: GC_mark_and_push_stack (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4D82E: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56557: GC_push_all_stacks (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   fun:GC_mark_and_push_stack
+   fun:GC_push_all_eager
+   fun:GC_push_all_stacks
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Use of uninitialised value of size 8
+==817==    at 0x4E4A476: GC_find_header (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E46A02: GC_add_to_black_list_stack (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4D82E: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56557: GC_push_all_stacks (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   fun:GC_find_header
+   fun:GC_add_to_black_list_stack
+   fun:GC_push_all_eager
+   fun:GC_push_all_stacks
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Conditional jump or move depends on uninitialised value(s)
+==817==    at 0x4E4A485: GC_find_header (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E46A02: GC_add_to_black_list_stack (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4D82E: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56557: GC_push_all_stacks (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:GC_find_header
+   fun:GC_add_to_black_list_stack
+   fun:GC_push_all_eager
+   fun:GC_push_all_stacks
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Use of uninitialised value of size 8
+==817==    at 0x4E4A4AF: GC_find_header (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E46A02: GC_add_to_black_list_stack (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4D82E: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56557: GC_push_all_stacks (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   fun:GC_find_header
+   fun:GC_add_to_black_list_stack
+   fun:GC_push_all_eager
+   fun:GC_push_all_stacks
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== Use of uninitialised value of size 8
+==817==    at 0x4E46A42: GC_add_to_black_list_stack (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4D82E: GC_push_all_eager (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E56557: GC_push_all_stacks (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4E24A: GC_mark_some (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E4532C: GC_stopped_mark (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E45CBE: GC_try_to_collect_inner (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x4E50482: GC_init (in /usr/lib/x86_64-linux-gnu/libgc.so.1.0.3)
+==817==    by 0x400DFC: _init (in /root/build/gc)
+==817==    by 0x4017FC: __libc_csu_init (in /root/build/gc)
+==817==    by 0x50C4ED4: (below main) (libc-start.c:246)
+==817== 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Value8
+   fun:GC_add_to_black_list_stack
+   fun:GC_push_all_eager
+   fun:GC_push_all_stacks
+   fun:GC_mark_some
+   fun:GC_stopped_mark
+   fun:GC_try_to_collect_inner
+   fun:GC_init
+   fun:_init
+   fun:__libc_csu_init
+   fun:(below main)
+}
+==817== 
+==817== HEAP SUMMARY:
+==817==     in use at exit: 0 bytes in 0 blocks
+==817==   total heap usage: 4 allocs, 4 frees, 960 bytes allocated
+==817== 
+==817== All heap blocks were freed -- no leaks are possible
+==817== 
+==817== For counts of detected and suppressed errors, rerun with: -v
+==817== Use --track-origins=yes to see where uninitialised values come from
+==817== ERROR SUMMARY: 353 errors from 18 contexts (suppressed: 0 from 0)


### PR DESCRIPTION
It's long been of interest to garbage-collect the memory that `get_string` allocates (and never frees) so that students can run `valgrind` even earlier in the term but not conflate memory leaks in the CS50 Library with memory leaks in their own code. `libgc` would appear to enable such, per the example at http://www.hboehm.info/gc/simple_example.html and the interface at http://www.hboehm.info/gc/gcinterface.html.

This PR proposes to:

* add a call to `GC_INIT` in `_init`
* rewrite calls to `malloc`, `realloc`, `calloc`, and `free` with `GC_` equivalents
* suppress resulting warnings from `valgrind` with [`valgrind/libgc.supp`](https://github.com/cs50/c/pull/15/files#diff-7c4f04a6b26ed7614a947c44f3b284f4) (that we'd need to install in CS50 IDE in `$PREFIX/lib/valgrind/`, per http://valgrind.org/docs/manual/manual-core.html#manual-core.suppress) that `libgc` itself has uninitialized values, per [`valgrind/valgrind.out`](https://github.com/cs50/c/pull/15/files#diff-dcc5958541cd102019a307d1f8f0c3b8)

This might affect the CS50 Library's portability, but we could potentially redress with some macros, disabling garbage collection if unsupported.

For a proof-of-concept test, run `make gc`.