### PR TITLE
rearrages deb files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ deb: build
 	fpm \
 	-m "$(MAINTAINER)" \
 	-n "$(NAME)" \
+	-C build \
 	-p build \
 	-s dir \
 	-t deb \
@@ -33,7 +34,7 @@ deb: build
 	--deb-no-default-config-files \
 	--depends libc-dev \
 	--description "$(DESCRIPTION)" \
-	build/usr
+	usr
 
 # TODO: add dependencies
 .PHONY: pacman


### PR DESCRIPTION
deb files were prefixed by build which caused them to end up getting
installed into build/\*, in the same directory as the deb package
instead of the intended path (i.e., usr/\*).

this fixes the problem by getting fpm to change dir to build, and
instructing it to build the usr dir.