### PR TITLE
fix chmod & remove fpm option as affects ownership

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ build: clean Makefile src/cs50.c src/cs50.h
 	gcc -o build/usr/local/lib/libcs50.a -shared build/cs50.o
 	rm -f build/cs50.o
 	cp src/cs50.h build/usr/local/include
-	chmod -R a+rX build
+	chmod -R 0755 build
+	find build -type f -exec chmod 0644 {} +
 
 .PHONY: clean
 clean:
@@ -34,7 +35,6 @@ deb: build
 	-t deb \
 	-v $(VERSION) \
 	--deb-no-default-config-files \
-	--deb-use-file-permissions \
 	--depends c-compiler \
 	--description "$(DESCRIPTION)" \
 	usr
@@ -51,7 +51,6 @@ pacman: build
 	-s dir \
 	-t pacman \
 	-v $(VERSION) \
-	--pacman-use-file-permissions \
 	--description "$(DESCRIPTION)" \
 	usr
 
@@ -67,7 +66,6 @@ rpm: build
 	-s dir \
 	-t rpm \
 	-v $(VERSION) \
-	--rpm-use-file-permissions \
 	--description "$(DESCRIPTION)" \
 	usr
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build: clean Makefile src/cs50.c src/cs50.h
 	gcc -o build/usr/local/lib/libcs50.a -shared build/cs50.o
 	rm -f build/cs50.o
 	cp src/cs50.h build/usr/local/include
-	chmod -R 0755 build
+	find build -type d -exec chmod 0755 {} +
 	find build -type f -exec chmod 0644 {} +
 
 .PHONY: clean


### PR DESCRIPTION
* explicitly chmod 0755 and 0644
* remove --*-use-file-permissions as affects ownership

@dmalan for some reason building a package with `--deb-use-file-permissions` affected the ownership of the files (trying to figure out why exactly). this is what we have after this commit:

```bash
/home/ubuntu/workspace/ $ sudo dpkg -i library50-c_7.0.0_amd64.deb 
Selecting previously unselected package library50-c.
(Reading database ... 44443 files and directories currently installed.)
Preparing to unpack library50-c_7.0.0_amd64.deb ...
Unpacking library50-c (7.0.0) ...
Setting up library50-c (7.0.0) ...
/home/ubuntu/workspace/ $ ls -la /usr/local/include/cs50.h 
-rw-r--r-- 1 root root 5171 Aug  5 14:35 /usr/local/include/cs50.h
/home/ubuntu/workspace/ $ ls -la /usr/local/lib/libcs50.a 
-rw-r--r-- 1 root root 13902 Aug  5 14:35 /usr/local/lib/libcs50.a
```